### PR TITLE
Inherit the default name override in features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ impl Config {
                                 if version_feature.starts_with('v') =>
                             {
                                 let mut override_version = None;
-                                let mut override_name = None;
+                                let mut override_name = lib_name;
 
                                 for (k, v) in version_settings {
                                     match (k.as_str(), v) {

--- a/src/test.rs
+++ b/src/test.rs
@@ -185,8 +185,15 @@ fn unexpected_key() {
 #[test]
 fn override_name() {
     let (libraries, _) = toml("toml-override-name", vec![]).unwrap();
-    let testlib = libraries.get("testlib").unwrap();
-    assert_eq!(testlib.version, "2.0.0");
+    let testlib = libraries.get("test_lib").unwrap();
+    assert_eq!(testlib.name, "testlib");
+    assert_eq!(testlib.version, "1.2.3");
+
+    // Enable feature 1.2
+    let (libraries, _) = toml("toml-override-name", vec![("CARGO_FEATURE_V1_2", "")]).unwrap();
+    let testlib = libraries.get("test_lib").unwrap();
+    assert_eq!(testlib.name, "testlib");
+    assert_eq!(testlib.version, "1.2.3");
 }
 
 #[test]
@@ -743,10 +750,10 @@ fn build_internal_override_name() {
     let (libraries, called) = test_build_internal(
         "toml-override-name",
         vec![("SYSTEM_DEPS_BUILD_INTERNAL", "always")],
-        "testlib-2.0",
+        "testlib",
     )
     .unwrap();
 
     assert_eq!(called, true);
-    assert!(libraries.get("testlib").is_some());
+    assert!(libraries.get("test_lib").is_some());
 }

--- a/src/tests/toml-override-name/Cargo.toml
+++ b/src/tests/toml-override-name/Cargo.toml
@@ -1,2 +1,2 @@
 [package.metadata.system-deps]
-testlib = { name = "testlib-2.0", version = "2" }
+test_lib = { name = "testlib", version = "1.0", v1_2 = { version = "1.2" } }


### PR DESCRIPTION
When the default feature overrides the name, also use it in the other features unless another override is declared there.