### PR TITLE
Remove dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ pkg-config = "0.3"
 toml = { version = "0.5", default-features = false }
 version-compare = "0.0.11"
 heck = "0.3"
-anyhow = "1.0"
 itertools = "0.10"
 cfg-expr = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ pkg-config = "0.3"
 toml = { version = "0.5", default-features = false }
 version-compare = "0.0.11"
 heck = "0.3"
-strum = "0.21"
-strum_macros = "0.21"
 thiserror = "1"
 anyhow = "1.0"
 itertools = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ pkg-config = "0.3"
 toml = { version = "0.5", default-features = false }
 version-compare = "0.0.11"
 heck = "0.3"
-itertools = "0.10"
 cfg-expr = "0.8"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ pkg-config = "0.3"
 toml = { version = "0.5", default-features = false }
 version-compare = "0.0.11"
 heck = "0.3"
-thiserror = "1"
 anyhow = "1.0"
 itertools = "0.10"
 cfg-expr = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,7 +290,7 @@ impl Dependencies {
             .flatten()
             .map(|s| s.as_str())
             .collect::<Vec<_>>();
-        v.sort();
+        v.sort_unstable();
         v.dedup();
         v
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,32 +307,32 @@ impl Dependencies {
         v
     }
 
-    /// An iterator returning each [Library::libs] of each library, removing duplicates.
+    /// Returns a vector of [Library::libs] of each library, removing duplicates.
     pub fn all_libs(&self) -> Vec<&str> {
         self.aggregate_str(|l| &l.libs)
     }
 
-    /// An iterator returning each [Library::link_paths] of each library, removing duplicates.
+    /// Returns a vector of [Library::link_paths] of each library, removing duplicates.
     pub fn all_link_paths(&self) -> Vec<&PathBuf> {
         self.aggregate_path_buf(|l| &l.link_paths)
     }
 
-    /// An iterator returning each [Library::frameworks] of each library, removing duplicates.
+    /// Returns a vector of [Library::frameworks] of each library, removing duplicates.
     pub fn all_frameworks(&self) -> Vec<&str> {
         self.aggregate_str(|l| &l.frameworks)
     }
 
-    /// An iterator returning each [Library::framework_paths] of each library, removing duplicates.
+    /// Returns a vector of [Library::framework_paths] of each library, removing duplicates.
     pub fn all_framework_paths(&self) -> Vec<&PathBuf> {
         self.aggregate_path_buf(|l| &l.framework_paths)
     }
 
-    /// An iterator returning each [Library::include_paths] of each library, removing duplicates.
+    /// Returns a vector of [Library::include_paths] of each library, removing duplicates.
     pub fn all_include_paths(&self) -> Vec<&PathBuf> {
         self.aggregate_path_buf(|l| &l.include_paths)
     }
 
-    /// An iterator returning each [Library::defines] of each library, removing duplicates.
+    /// Returns a vector of [Library::defines] of each library, removing duplicates.
     pub fn all_defines(&self) -> Vec<(&str, &Option<String>)> {
         let mut v = self
             .libs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,6 @@ extern crate lazy_static;
 mod test;
 
 use heck::{ShoutySnakeCase, SnakeCase};
-use itertools::Itertools;
 use std::collections::HashMap;
 use std::env;
 use std::fmt;
@@ -276,65 +275,68 @@ impl Dependencies {
         self.libs.iter().map(|(k, v)| (k.as_str(), v))
     }
 
-    fn aggregate_str<F: Fn(&Library) -> &Vec<String>>(
-        &self,
-        getter: F,
-    ) -> impl Iterator<Item = &str> {
-        self.libs
+    fn aggregate_str<F: Fn(&Library) -> &Vec<String>>(&self, getter: F) -> Vec<&str> {
+        let mut v = self
+            .libs
             .values()
             .map(|l| getter(l))
             .flatten()
             .map(|s| s.as_str())
-            .sorted()
-            .dedup()
+            .collect::<Vec<_>>();
+        v.sort();
+        v.dedup();
+        v
     }
 
-    fn aggregate_path_buf<F: Fn(&Library) -> &Vec<PathBuf>>(
-        &self,
-        getter: F,
-    ) -> impl Iterator<Item = &PathBuf> {
-        self.libs
+    fn aggregate_path_buf<F: Fn(&Library) -> &Vec<PathBuf>>(&self, getter: F) -> Vec<&PathBuf> {
+        let mut v = self
+            .libs
             .values()
             .map(|l| getter(l))
             .flatten()
-            .sorted()
-            .dedup()
+            .collect::<Vec<_>>();
+        v.sort();
+        v.dedup();
+        v
     }
 
     /// An iterator returning each [Library::libs] of each library, removing duplicates.
-    pub fn all_libs(&self) -> impl Iterator<Item = &str> {
+    pub fn all_libs(&self) -> Vec<&str> {
         self.aggregate_str(|l| &l.libs)
     }
 
     /// An iterator returning each [Library::link_paths] of each library, removing duplicates.
-    pub fn all_link_paths(&self) -> impl Iterator<Item = &PathBuf> {
+    pub fn all_link_paths(&self) -> Vec<&PathBuf> {
         self.aggregate_path_buf(|l| &l.link_paths)
     }
 
     /// An iterator returning each [Library::frameworks] of each library, removing duplicates.
-    pub fn all_frameworks(&self) -> impl Iterator<Item = &str> {
+    pub fn all_frameworks(&self) -> Vec<&str> {
         self.aggregate_str(|l| &l.frameworks)
     }
 
     /// An iterator returning each [Library::framework_paths] of each library, removing duplicates.
-    pub fn all_framework_paths(&self) -> impl Iterator<Item = &PathBuf> {
+    pub fn all_framework_paths(&self) -> Vec<&PathBuf> {
         self.aggregate_path_buf(|l| &l.framework_paths)
     }
 
     /// An iterator returning each [Library::include_paths] of each library, removing duplicates.
-    pub fn all_include_paths(&self) -> impl Iterator<Item = &PathBuf> {
+    pub fn all_include_paths(&self) -> Vec<&PathBuf> {
         self.aggregate_path_buf(|l| &l.include_paths)
     }
 
     /// An iterator returning each [Library::defines] of each library, removing duplicates.
-    pub fn all_defines(&self) -> impl Iterator<Item = (&str, &Option<String>)> {
-        self.libs
+    pub fn all_defines(&self) -> Vec<(&str, &Option<String>)> {
+        let mut v = self
+            .libs
             .values()
             .map(|l| l.defines.iter())
             .flatten()
             .map(|(k, v)| (k.as_str(), v))
-            .sorted()
-            .dedup()
+            .collect::<Vec<_>>();
+        v.sort();
+        v.dedup();
+        v
     }
 
     fn add(&mut self, name: &str, lib: Library) {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -154,7 +154,7 @@ impl VersionOverrideBuilder {
     fn build(self) -> Result<VersionOverride, VersionOverrideBuilderError> {
         let version = self
             .version
-            .ok_or_else(|| VersionOverrideBuilderError::MissingVersionField)?;
+            .ok_or(VersionOverrideBuilderError::MissingVersionField)?;
 
         Ok(VersionOverride {
             key: self.version_id,

--- a/src/test.rs
+++ b/src/test.rs
@@ -815,31 +815,28 @@ fn optional() {
 fn aggregate() {
     let (libraries, _) = toml("toml-two-libs", vec![]).unwrap();
 
+    assert_eq!(libraries.all_libs(), vec!["test", "test2"]);
     assert_eq!(
-        libraries.all_libs().collect::<Vec<&str>>(),
-        vec!["test", "test2"]
-    );
-    assert_eq!(
-        libraries.all_link_paths().collect::<Vec<&PathBuf>>(),
+        libraries.all_link_paths(),
         vec![Path::new("/usr/lib"), Path::new("/usr/lib64")]
     );
     assert_eq!(
-        libraries.all_frameworks().collect::<Vec<&str>>(),
+        libraries.all_frameworks(),
         vec!["someframework", "someotherframework"]
     );
     assert_eq!(
-        libraries.all_framework_paths().collect::<Vec<&PathBuf>>(),
+        libraries.all_framework_paths(),
         vec![Path::new("/usr/lib"), Path::new("/usr/lib64")]
     );
     assert_eq!(
-        libraries.all_include_paths().collect::<Vec<&PathBuf>>(),
+        libraries.all_include_paths(),
         vec![
             Path::new("/usr/include/testanotherlib"),
             Path::new("/usr/include/testlib")
         ]
     );
     assert_eq!(
-        libraries.all_defines().collect::<Vec<_>>(),
+        libraries.all_defines(),
         vec![
             ("AWESOME", &None),
             ("BADGER", &Some("yes".into())),

--- a/src/test.rs
+++ b/src/test.rs
@@ -153,12 +153,18 @@ fn missing_file() {
 
 #[test]
 fn missing_key() {
-    toml_err_invalid("toml-missing-key", "no package.metadata.system-deps");
+    toml_err_invalid(
+        "toml-missing-key",
+        "missing key `package.metadata.system-deps`",
+    );
 }
 
 #[test]
 fn not_table() {
-    toml_err_invalid("toml-not-table", "package.metadata.system-deps not a table");
+    toml_err_invalid(
+        "toml-not-table",
+        "`package.metadata.system-deps` is not a table",
+    );
 }
 
 #[test]
@@ -170,7 +176,7 @@ fn version_missing() {
 fn version_not_string() {
     toml_err_invalid(
         "toml-version-not-string",
-        "metadata.system-deps.testlib: not a string or table",
+        "`package.metadata.system-deps.testlib`: not a string or a table",
     );
 }
 


### PR DESCRIPTION
With this, no more proc-macro (which was the biggest problem). It makes the code more explicit and much faster to compile and reducing the network usage when getting the crates for the first time.

I splitted the removal in different commits to make it easier to review.

Fixes #49.