### PR TITLE
Fix statically linked libraries that have dynamically linked dependencies

### DIFF
--- a/src/tests/teststaticlib.pc
+++ b/src/tests/teststaticlib.pc
@@ -1,0 +1,10 @@
+prefix=./src/tests
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib/
+includedir=${prefix}/include/testlib
+
+Name: Test Library
+Description: A fake library to test pkg-config.
+Version: 1.2.3
+Libs: -L${libdir} -lteststatic -F${libdir} -framework someframework
+Cflags: -I${includedir} -DBADGER=yes -DAWESOME

--- a/src/tests/toml-static/Cargo.toml
+++ b/src/tests/toml-static/Cargo.toml
@@ -1,0 +1,4 @@
+[package.metadata.system-deps]
+testdata = "4"
+teststaticlib = { version = "1", feature = "test-feature" }
+testmore = { version = "2", feature = "another-test-feature" }


### PR DESCRIPTION
I had an issue compiling https://github.com/rust-av/dav1d-rs with `SYSTEM_DEPS_DAV1D_LINK=static`
`libdav1d` has the implicit dynamically linked dependency `dl` on linux, which caused issues, as every dependency of the library (which is `dl` and `dav1d`) is linked statically if specified with `SYSTEM_DEPS_<NAME>_LINK`

This PR is mostly copied code from the `pkg_config` crate (specifically the private function `is_static_available`). It checks for each dependency of a library, if the dependency is available as static library and if not, it tries to link dynamically.

I'm not sure if there is a more elegant solution for this issue.