### PR TITLE
Bump version-compare to 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 pkg-config = "0.3"
 toml = { version = "0.5", default-features = false }
-version-compare = "0.0.11"
+version-compare = "0.1"
 heck = "0.3"
 cfg-expr = "0.9"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,6 @@ use std::env;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use version_compare::VersionCompare;
 
 mod metadata;
 use metadata::MetaData;
@@ -688,7 +687,7 @@ impl Config {
                 // Pick the highest feature enabled version
                 if !enabled_feature_overrides.is_empty() {
                     enabled_feature_overrides.sort_by(|a, b| {
-                        VersionCompare::compare(&a.version, &b.version)
+                        version_compare::compare(&a.version, &b.version)
                             .expect("failed to compare versions")
                             .ord()
                             .expect("invalid version")
@@ -784,8 +783,8 @@ impl Config {
         };
 
         // Check that the lib built internally matches the required version
-        match VersionCompare::compare(&lib.version, version) {
-            Ok(version_compare::CompOp::Lt) => Err(Error::BuildInternalWrongVersion(
+        match version_compare::compare(&lib.version, version) {
+            Ok(version_compare::Cmp::Lt) => Err(Error::BuildInternalWrongVersion(
                 name.into(),
                 lib.version.clone(),
                 version.into(),


### PR DESCRIPTION
Bumps `version-compare` to the next version with a slightly changed API.

Not high-priority, but nice anyway.