### PR TITLE
Update heck to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 pkg-config = "0.3"
 toml = { version = "0.5", default-features = false }
 version-compare = "0.1"
-heck = "0.3"
+heck = "0.4"
 cfg-expr = "0.9"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ extern crate lazy_static;
 #[cfg(test)]
 mod test;
 
-use heck::{ShoutySnakeCase, SnakeCase};
+use heck::{ToShoutySnakeCase, ToSnakeCase};
 use std::collections::HashMap;
 use std::env;
 use std::fmt;


### PR DESCRIPTION
The heck crate has been updated, and other crates are using the latest versions already. However, 0.4 has some breaking changes compared to 0.3, which I took care of in this PR. The heck repository contains a [changelog](https://github.com/withoutboats/heck/blob/dbcfc7b8db8e532d1fad44518cf73e88d5212161/CHANGELOG.md) with more information.