### PR TITLE
Update `cfg-expr` to version 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pkg-config = "0.3"
 toml = { version = "0.5", default-features = false }
 version-compare = "0.1"
 heck = "0.4"
-cfg-expr = "0.10"
+cfg-expr = "0.11"
 
 [dev-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
IIUC this will allow using recently added Rust's new target.
Curently released version fails with: https://gist.github.com/lazka/d7f8fa3d605bdd31ed7bf16a2ff8801c but unfortunately I don't have AArch64 machine to test it.