### PR TITLE
Add support for non-builtin targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pkg-config = "0.3"
 toml = { version = "0.7", default-features = false, features = ["parse"] }
 version-compare = "0.1"
 heck = "0.4"
-cfg-expr = "0.14"
+cfg-expr = { version = "0.15", features = ["targets"] }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/src/test.rs
+++ b/src/test.rs
@@ -867,7 +867,7 @@ fn aggregate() {
 fn os_specific() {
     let (libraries, _) = toml(
         "toml-os-specific",
-        vec![("TARGET", "x86_64-unknown-linux-gnu")],
+        vec![("TARGET", "x86_64-alpine-linux-musl")],
     )
     .unwrap();
     assert!(libraries.get_by_name("testdata").is_some());


### PR DESCRIPTION
Apparently [alpine patches rustc](https://github.com/alpinelinux/aports/blob/master/community/rust/alpine-target.patch) and adds targets that aren't in the official compiler, so this PR just adds support for falling back to attempting to parse the triple to do evaluation, rather than failing for those with patched compilers.

Resolves: https://github.com/EmbarkStudios/cfg-expr/issues/55