### PR TITLE
Add fallback names to probe to account for platform differences

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -222,6 +222,91 @@ fn override_name() {
 }
 
 #[test]
+fn fallback_names() {
+    let (libraries, flags) = toml("toml-fallback-names", vec![]).unwrap();
+    let testlib = libraries.get_by_name("test_lib").unwrap();
+    assert_eq!(testlib.name, "testlib");
+    assert_eq!(testlib.version, "1.2.3");
+
+    eprintln!();
+    eprintln!("{flags}");
+    assert_flags(
+        flags,
+        r#"cargo:rustc-link-search=native=/usr/lib/
+cargo:rustc-link-search=framework=/usr/lib/
+cargo:rustc-link-lib=test
+cargo:rustc-link-lib=framework=someframework
+cargo:include=/usr/include/testlib
+cargo:rerun-if-env-changed=SYSTEM_DEPS_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_LINK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LIB
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LIB_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_SEARCH_NATIVE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_SEARCH_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_INCLUDE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_NO_PKG_CONFIG
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LINK
+"#,
+    );
+}
+
+#[test]
+fn version_fallback_names() {
+    let (libraries, flags) = toml("toml-version-fallback-names", vec![]).unwrap();
+    let testlib = libraries.get_by_name("test_lib").unwrap();
+    assert_eq!(testlib.name, "testlib");
+    assert_eq!(testlib.version, "1.2.3");
+    assert_flags(
+        flags,
+        r#"cargo:rustc-link-search=native=/usr/lib/
+cargo:rustc-link-search=framework=/usr/lib/
+cargo:rustc-link-lib=test
+cargo:rustc-link-lib=framework=someframework
+cargo:include=/usr/include/testlib
+cargo:rerun-if-env-changed=SYSTEM_DEPS_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_LINK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LIB
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LIB_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_SEARCH_NATIVE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_SEARCH_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_INCLUDE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_NO_PKG_CONFIG
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LINK
+"#,
+    );
+
+    // Now try with v2 feature enabled.
+    let (libraries, flags) = toml(
+        "toml-version-fallback-names",
+        vec![("CARGO_FEATURE_V2", "")],
+    )
+    .unwrap();
+    let testlib = libraries.get_by_name("test_lib").unwrap();
+    assert_eq!(testlib.name, "testlib-2.0");
+    assert_eq!(testlib.version, "2.0.0");
+
+    assert_flags(
+        flags,
+        r#"cargo:rustc-link-search=native=/usr/lib/
+cargo:rustc-link-lib=test
+cargo:include=/usr/include/testlib
+cargo:rerun-if-env-changed=SYSTEM_DEPS_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_LINK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LIB
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LIB_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_SEARCH_NATIVE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_SEARCH_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_INCLUDE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_NO_PKG_CONFIG
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TEST_LIB_LINK
+"#,
+    );
+}
+
+#[test]
 fn feature_versions() {
     let (libraries, _) = toml("toml-feature-versions", vec![]).unwrap();
     let testdata = libraries.get_by_name("testdata").unwrap();

--- a/src/tests/testlib-2.0.pc
+++ b/src/tests/testlib-2.0.pc
@@ -6,5 +6,5 @@ includedir=${prefix}/include/testlib
 Name: Test Library
 Description: A fake library to test pkg-config.
 Version: 2.0.0
-Libs: L${libdir} -ltest
+Libs: -L${libdir} -ltest
 Cflags: -I${includedir}

--- a/src/tests/testlib-3.0.pc
+++ b/src/tests/testlib-3.0.pc
@@ -6,5 +6,5 @@ includedir=${prefix}/include/testlib
 Name: Test Library
 Description: A fake library to test pkg-config.
 Version: 3.0.0
-Libs: L${libdir} -ltest
+Libs: -L${libdir} -ltest
 Cflags: -I${includedir}

--- a/src/tests/toml-fallback-names/Cargo.toml
+++ b/src/tests/toml-fallback-names/Cargo.toml
@@ -1,0 +1,4 @@
+[package.metadata.system-deps.test_lib]
+version = "1.0"
+name = "nosuchlib"
+fallback-names = ["also-no-such-lib", "testlib", "should-not-get-here"]

--- a/src/tests/toml-version-fallback-names/Cargo.toml
+++ b/src/tests/toml-version-fallback-names/Cargo.toml
@@ -1,0 +1,7 @@
+[package.metadata.system-deps.test_lib]
+version = "0.1"
+name = "nosuchlib"
+fallback-names = ["also-no-such-lib", "testlib", "should-not-get-here"]
+v1 = { version = "1.0" }
+v2 = { version = "2.0", fallback-names = ["testlib-2.0"] }
+v99 = { version = "99.0", fallback-names = [] }


### PR DESCRIPTION
This PR adds support for `fallback-names` to allow dealing with different names on different platforms. It also updates the documentation and adds tests. The user can specify `fallback-names` directly on the dependency entry, and on the version overrides.