### PR TITLE
Honor manual requests for static linking

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,9 +383,18 @@ impl Dependencies {
                 lib.framework_paths = split_paths(&value);
             }
             if let Some(value) = env.get(&EnvVariable::new_lib(name)) {
+                let should_be_linked_statically = env
+                    .has_value(&EnvVariable::new_link(Some(name)), "static")
+                    || env.has_value(&EnvVariable::new_link(None), "static");
+
+                // If somebody manually mandates static linking, that is a
+                // clear intent. Let's just assume that a static lib is
+                // available and let the linking fail if the user is wrong.
+                let is_static_lib_available = should_be_linked_statically;
+
                 lib.libs = split_string(&value)
                     .into_iter()
-                    .map(|l| InternalLib::new(l, false))
+                    .map(|l| InternalLib::new(l, is_static_lib_available))
                     .collect();
             }
             if let Some(value) = env.get(&EnvVariable::new_lib_framework(name)) {

--- a/src/test.rs
+++ b/src/test.rs
@@ -1031,6 +1031,53 @@ cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_LINK
 }
 
 #[test]
+fn override_static_no_pkg_config() {
+    let (libraries, flags) = toml(
+        "toml-static",
+        vec![
+            ("SYSTEM_DEPS_TESTSTATICLIB_NO_PKG_CONFIG", "1"),
+            ("SYSTEM_DEPS_TESTSTATICLIB_LIB", "custom-lib"),
+            ("SYSTEM_DEPS_TESTSTATICLIB_LINK", "static"),
+        ],
+    )
+    .unwrap();
+    let testlib = libraries.get_by_name("teststaticlib").unwrap();
+    assert_eq!(testlib.link_paths, Vec::<PathBuf>::new());
+    assert_eq!(testlib.statik, true);
+    assert_eq!(testlib.framework_paths, Vec::<PathBuf>::new());
+    assert_eq!(
+        testlib.libs,
+        vec![InternalLib::new("custom-lib".to_string(), true)]
+    );
+    assert_eq!(testlib.frameworks, Vec::<String>::new());
+    assert_eq!(testlib.include_paths, Vec::<PathBuf>::new());
+
+    assert_flags(
+        flags,
+        r"cargo:rustc-link-lib=static=custom-lib
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_INCLUDE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_LIB
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_LIB_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_NO_PKG_CONFIG
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_SEARCH_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_SEARCH_NATIVE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTSTATICLIB_INCLUDE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTSTATICLIB_LIB
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTSTATICLIB_LIB_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTSTATICLIB_NO_PKG_CONFIG
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTSTATICLIB_SEARCH_FRAMEWORK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTSTATICLIB_SEARCH_NATIVE
+cargo:rerun-if-env-changed=SYSTEM_DEPS_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTSTATICLIB_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_BUILD_INTERNAL
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTDATA_LINK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_TESTSTATICLIB_LINK
+cargo:rerun-if-env-changed=SYSTEM_DEPS_LINK
+",
+    );
+}
+
+#[test]
 fn static_all_libs() {
     let (libraries, flags) = toml("toml-static", vec![("SYSTEM_DEPS_LINK", "static")]).unwrap();
 


### PR DESCRIPTION
This allows a user to statically link a library even when not using pkg-config as source. Previously, if SYSTEM_DEPS_<LIB>_NO_PKG_CONFIG was set, the SYSTEM_DEPS_<LIB>_LINK=static configuration was ignored.

Since the user already went above and beyond to issue a strong intent of static linking, no check is performed whether the file actually exists. The linker will scream if something is wrong.