### PR TITLE
bump minimum required cfg-expr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pkg-config = "0.3.23"
 toml = { version = "0.8", default-features = false, features = ["parse"] }
 version-compare = "0.1"
 heck = "0.4"
-cfg-expr = { version = "0.15", features = ["targets"] }
+cfg-expr = { version = "0.15.5", features = ["targets"] }
 
 [dev-dependencies]
 lazy_static = "1"


### PR DESCRIPTION
to fix minimal-versions build

cf https://github.com/EmbarkStudios/cfg-expr/pull/63