### PR TITLE
Implement support for requiring dependency version ranges

### DIFF
--- a/src/tests/toml-version-range-unsatisfied/Cargo.toml
+++ b/src/tests/toml-version-range-unsatisfied/Cargo.toml
@@ -1,0 +1,3 @@
+[package.metadata.system-deps]
+testdata = "4"
+testlib = { version = ">= 1, < 1.2", feature = "test-feature" }

--- a/src/tests/toml-version-range/Cargo.toml
+++ b/src/tests/toml-version-range/Cargo.toml
@@ -1,0 +1,3 @@
+[package.metadata.system-deps]
+testdata = "4"
+testlib = { version = ">= 1, < 2", feature = "test-feature" }


### PR DESCRIPTION
This now supports expressions in the form

  * "1.2" or ">= 1.2" for at least version 1.2
  * ">= 1.2, < 2.0" for at least version 1.2 and less than version 2.0

Fixes https://github.com/gdesmott/system-deps/issues/60

----

@gdesmott Does this look reasonable to you? As discussed, semver can't really be used here because pkg-config versions don't follow semver. A version of "1.2" is semver ">= 1.2, < 2.0" and that is more semantics than pkg-config versions have.