### PR TITLE
Add names to test manifests

### DIFF
--- a/src/tests/toml-fallback-names/Cargo.toml
+++ b/src/tests/toml-fallback-names/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-fallback-names"
+
 [package.metadata.system-deps.test_lib]
 version = "1.0"
 name = "nosuchlib"

--- a/src/tests/toml-feature-not-string/Cargo.toml
+++ b/src/tests/toml-feature-not-string/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-feature-not-string"
+
 [package.metadata.system-deps]
 testlib = { version = "1", feature = 2 }

--- a/src/tests/toml-feature-versions/Cargo.toml
+++ b/src/tests/toml-feature-versions/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-feature-versions"
+
 [package.metadata.system-deps]
 testdata = { version = "4", v5 = { version = "5" }, v6 = { version = "6" }}

--- a/src/tests/toml-good/Cargo.toml
+++ b/src/tests/toml-good/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-good"
+
 [package.metadata.system-deps]
 testdata = "4"
 testlib = { version = "1", feature = "test-feature" }

--- a/src/tests/toml-invalid-cfg/Cargo.toml
+++ b/src/tests/toml-invalid-cfg/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-invalid-cfg"
+
 [package.metadata.system-deps.'cfg(badger)']
 testanotherlib = { version = "1", optional = true }

--- a/src/tests/toml-missing-key/Cargo.toml
+++ b/src/tests/toml-missing-key/Cargo.toml
@@ -1,1 +1,4 @@
+[package]
+name = "toml-missing-key"
+
 no-pkg-config-here = true

--- a/src/tests/toml-not-table/Cargo.toml
+++ b/src/tests/toml-not-table/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-not-table"
+
 [package.metadata]
 system-deps = "not a table"

--- a/src/tests/toml-optional/Cargo.toml
+++ b/src/tests/toml-optional/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-optional"
+
 [package.metadata.system-deps]
 testlib = { version = "1.0", optional = true, v5 = { version = "5.0", name = "testlib-5.0", optional = false }}
 testmore = { version = "2", v3 = { version = "3.0", optional = true }}

--- a/src/tests/toml-os-specific/Cargo.toml
+++ b/src/tests/toml-os-specific/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-os-specific"
+
 [package.metadata.system-deps.'cfg(target_os = "linux")']
 testdata = "1"
 [package.metadata.system-deps.'cfg(not(target_os = "macos"))']

--- a/src/tests/toml-override-name/Cargo.toml
+++ b/src/tests/toml-override-name/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-override-name"
+
 [package.metadata.system-deps]
 test_lib = { name = "testlib", version = "1.0", v1_2 = { version = "1.2" } }

--- a/src/tests/toml-rpath/Cargo.toml
+++ b/src/tests/toml-rpath/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-rpath"
+
 [package.metadata.system-deps]
 testdata = "4"
 testlibwithrpath = { version = "1", feature = "test-feature" }

--- a/src/tests/toml-static/Cargo.toml
+++ b/src/tests/toml-static/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-static"
+
 [package.metadata.system-deps]
 testdata = "4"
 teststaticlib = { version = "1", feature = "test-feature" }

--- a/src/tests/toml-two-libs/Cargo.toml
+++ b/src/tests/toml-two-libs/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-two-libs"
+
 [package.metadata.system-deps]
 testlib = { version = "1" }
 testanotherlib = { version = "1" }

--- a/src/tests/toml-unexpected-key/Cargo.toml
+++ b/src/tests/toml-unexpected-key/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-unexpected-key"
+
 [package.metadata.system-deps]
 testlib = { version = "1", color = "blue" }

--- a/src/tests/toml-version-fallback-names/Cargo.toml
+++ b/src/tests/toml-version-fallback-names/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-version-fallback-names"
+
 [package.metadata.system-deps.test_lib]
 version = "0.1"
 name = "nosuchlib"

--- a/src/tests/toml-version-in-table-not-string/Cargo.toml
+++ b/src/tests/toml-version-in-table-not-string/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-version-in-table-not-string"
+
 [package.metadata.system-deps]
 testlib = { version = 1 }

--- a/src/tests/toml-version-missing/Cargo.toml
+++ b/src/tests/toml-version-missing/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-version-missing"
+
 [package.metadata.system-deps]
 testlib = { feature = "test-feature" }

--- a/src/tests/toml-version-names/Cargo.toml
+++ b/src/tests/toml-version-names/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-version-names"
+
 [package.metadata.system-deps]
 testlib = { version = "1.2", v2 = { version = "2.0", name = "testlib-2.0" }, v3 = { version = "3.0", name = "testlib-3.0" }}

--- a/src/tests/toml-version-not-string/Cargo.toml
+++ b/src/tests/toml-version-not-string/Cargo.toml
@@ -1,2 +1,5 @@
+[package]
+name = "toml-version-not-string"
+
 [package.metadata.system-deps]
 testlib = 1

--- a/src/tests/toml-version-range-unsatisfied/Cargo.toml
+++ b/src/tests/toml-version-range-unsatisfied/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-version-range-unsatisfied"
+
 [package.metadata.system-deps]
 testdata = "4"
 testlib = { version = ">= 1, < 1.2", feature = "test-feature" }

--- a/src/tests/toml-version-range/Cargo.toml
+++ b/src/tests/toml-version-range/Cargo.toml
@@ -1,3 +1,6 @@
+[package]
+name = "toml-version-range"
+
 [package.metadata.system-deps]
 testdata = "4"
 testlib = { version = ">= 1, < 2", feature = "test-feature" }


### PR DESCRIPTION
When using `system-deps` as a git or local dependency instead of the version from `crates.io`, cargo generates errors because the `Cargo.toml` files from the tests don't have the [`name`](https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field) field, even if they are not real manifests. It still compiles, but the output is very verbose and it could be misleading.

```
error: missing field `name`
 --> ../../../.cargo/git/checkouts/system-deps-3c68ab912ff25118/6fcbb37/src/tests/toml-fallback-names/Cargo.toml:1:2
  |
1 | [package.metadata.system-deps.test_lib]
  |  ^^^^^^^
  |
... (many lines like this)
```

This PR just adds the field to the existing manifest with the same name as the test. This shouldn't have any other effects than removing the warnings.

Tested with `cargo 1.82.0 (8f40fc59f 2024-08-21)`