### PR TITLE
Allow to set environment variables from build script

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -45,7 +45,10 @@ fn create_config(path: &str, env: Vec<(&'static str, &'static str)>) -> Config {
         hash.insert(k, v.to_string());
     });
 
-    Config::new_with_env(EnvVariables::Mock(hash))
+    Config::new_with_env(EnvVariables::Mock {
+        vars: hash,
+        fallback: false,
+    })
 }
 
 fn toml(


### PR DESCRIPTION
`system-deps` provides many environment variables to configure its options. This is great for end users, but it doesn't allow libraries to provide defaults or configure them programmatically.

An improvement could be to have a `add_env` method in the build script configuration that will add certain values to its environment (it doesn't set the real env variable). Since `system-deps` already had a `Mock` variable type tests, we can reuse it, providing a fallback to the environment in the case of build scripts and not doing so in tests.

### Use cases

- Configuring `system-deps` options using crate features. For example, a crate could have a feature that determines if it is statically or dynamically linked, and using `add_env` we can set the relevant variable from the build script.
- Allow dependencies to provide defaults, for example, set [linking line deduplication](https://github.com/gdesmott/system-deps/pull/113) if the crate requires it.
- Better interface with other env variables specific to the crate. If a package already reads the option `SOME_CONFIG`, it can now also set needed `system-deps` variables.

### Considered alternatives

- Use [`.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html#environment-variables) to set `[env]` variables per target. However, rust [doesn't allow to use features](https://github.com/rust-lang/cargo/issues/10273) to configure these values, and dependencies can't share this with users.
- Build scripts can emit [environment variables](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env) and [metadata](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key) using cargo directives. However, the first is only passed to it's corresponding library, and the second only sends the metadata to its dependent crates, not its dependencies (like `system-deps`).
- Users can set the variables directly or with a Makefile/similar script. However, this requires extra configuration when using a dependency and it can cause unexpected issues.

### TODO:

- [ ] Should the environment or the set variables have priority? I'm leaning towards the current implementation (set variables shadow environment) since then the decision lays on the crate using `system-deps`. They can read the environment and decide whether to use it or not.
- [ ] Add tests.
- [ ] Link related PRs.

**Note:** This was originally part of the PR for supporting prebuilt binaries (ADD LINK). However, in an effort to make reviewing easy, I separated this feature since it works independently.