### PR TITLE
chore: bump toml to version 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 
 [dependencies]
 pkg-config = "0.3.25"
-toml = { version = "0.9", default-features = false, features = ["parse", "std"] }
+toml = { version = "1", default-features = false, features = ["parse", "std"] }
 version-compare = "0.2"
 heck = "0.5"
 # allow cfg-expr between 0.17 and 0.20 to keep MSRV lower


### PR DESCRIPTION
Update to allow downstream users to rely on `toml` 1.X without breaking semver checks.
No breaking change in 1.X