### PR TITLE
Support dynamic linking for prebuilt binaries

### DIFF
--- a/meta/src/binary.rs
+++ b/meta/src/binary.rs
@@ -236,19 +236,25 @@ impl Paths {
     /// Returns the list of paths for a certain package. Matches wildcards but they never have
     /// priority over explicit urls or follows, even if they are defined higher in the hierarchy.
     pub fn get(&self, key: &str) -> Option<&Vec<PathBuf>> {
-        if let Some(paths) = self.paths.get(key) {
-            return Some(paths);
-        };
+        self.provider(key).and_then(|p| self.paths.get(p))
+    }
+
+    /// Name of the package whose prebuilt binaries provide `key`, if any.
+    pub fn provider(&self, key: &str) -> Option<&str> {
+        if let Some(provider) = self.paths.get_key_value(key) {
+            return Some(provider.0.as_str());
+        }
 
         if let Some(follows) = self.follows.get(key) {
-            return self.paths.get(follows);
-        };
+            return self.paths.contains_key(follows).then_some(follows.as_str());
+        }
 
-        self.wildcards.iter().find_map(|(k, v)| {
-            key.starts_with(k)
-                .then_some(v)
-                .and_then(|v| self.paths.get(v))
-        })
+        self.wildcards
+            .iter()
+            .find(|(prefix, provider)| {
+                key.starts_with(prefix.as_str()) && self.paths.contains_key(*provider)
+            })
+            .map(|(_, provider)| provider.as_str())
     }
 
     /// Serializes the path list.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@
 //! You can also use the `SYSTEM_DEPS_BUILD_INTERNAL` environment variable with the same values
 //! defining the behavior for all the dependencies which don't have `SYSTEM_DEPS_$NAME_BUILD_INTERNAL` defined.
 //!
-//! # Static linking
+//! # Linking
 //!
 //! By default all libraries are dynamically linked, except when build internally as [described above](#internally-build-system-libraries).
 //! Libraries can be statically linked by defining the environment variable `SYSTEM_DEPS_$NAME_LINK=static`.
@@ -205,6 +205,16 @@
 //!
 //! The libraries specified with this option can have any form readable by `pkg-config`, and they will inherit the main libraries'
 //! binary paths if you are using them. If `pkg-config` can't find some entry, it will print a warning but the compilation won't fail.
+//!
+//! Prebuilt binaries are statically linked by default. Set `SYSTEM_DEPS_$NAME_LINK=dynamic` or
+//! `SYSTEM_DEPS_LINK=dynamic` to use dynamic linking instead. `SYSTEM_DEPS_$NAME_LINK` applies to
+//! every package that binary provides through `follows` and wildcard `provides`, so that its
+//! archives and shared libraries are never mixed.
+//!
+//! A dynamically linked bundle is not installed in a system directory, so the final binary has to
+//! be told where to find it. [`Config::print_binary_link_args`] prints the link-search and rpath
+//! flags for it. Call it from the build script of the package that produces the executable or
+//! shared library.
 //!
 //! # Using prebuilt binaries
 //!
@@ -317,6 +327,8 @@ pub enum Error {
     BuildInternalWrongVersion(String, String, String),
     /// The `cfg()` expression used in `Cargo.toml` is currently not supported
     UnsupportedCfg(String),
+    /// Two packages provided by the same prebuilt binary resolved to different link modes
+    LinkModeMismatch(String, String),
 }
 
 impl From<pkg_config::Error> for Error {
@@ -358,6 +370,12 @@ impl fmt::Display for Error {
                 "Internally built {s1} {s2} but minimum required version is {s3}"
             ),
             Self::UnsupportedCfg(s) => write!(f, "Unsupported cfg() expression: {s}"),
+            Self::LinkModeMismatch(name, package) => write!(
+                f,
+                "{package} is provided by {name}, but they resolve to different link modes; \
+                 set {} to link both the same way",
+                EnvVariable::new_link(Some(name)),
+            ),
         }
     }
 }
@@ -366,6 +384,7 @@ impl fmt::Display for Error {
 /// All the system dependencies retrieved by [`Config::probe`].
 pub struct Dependencies {
     libs: BTreeMap<String, Library>,
+    providers: Vec<String>,
 }
 
 impl Dependencies {
@@ -600,6 +619,11 @@ impl Dependencies {
 
         for name in self.libs.keys() {
             EnvVariable::set_rerun_if_changed_for_all_variants(&mut flags, name);
+        }
+
+        for provider in &self.providers {
+            let var = EnvVariable::new_link(Some(provider));
+            flags.add(BuildFlag::RerunIfEnvChanged(var));
         }
 
         Ok(flags)
@@ -874,6 +898,87 @@ impl Config {
             .map_or_else(|| self.paths.get(_pkg), |_| None)
     }
 
+    /// Name of the package whose prebuilt binaries provide `_pkg`, if any.
+    fn provider(&self, _pkg: &str) -> Option<&str> {
+        #[cfg(not(feature = "binary"))]
+        return None;
+
+        #[cfg(feature = "binary")]
+        self.paths.provider(_pkg)
+    }
+
+    /// Check if the dependency should be statically linked.
+    fn link_mode(&self, pkg: &str) -> bool {
+        let provider = self.provider(pkg);
+        let vars = [
+            Some(EnvVariable::new_link(Some(pkg))),
+            provider
+                .filter(|provider| *provider != pkg)
+                .map(|provider| EnvVariable::new_link(Some(provider))),
+            Some(EnvVariable::new_link(None)),
+        ];
+
+        match vars.iter().flatten().find_map(|var| self.env.get(var)) {
+            Some(mode) => mode == "static",
+            None => provider.is_some(),
+        }
+    }
+
+    /// Configure the build to link against the shared libraries of a prebuilt
+    /// binary bundle, which are loaded from `runtime_subdir` next to the built
+    /// artifact at runtime.
+    #[cfg(feature = "binary")]
+    pub fn print_binary_link_args(&self, pkg: &str, runtime_subdir: &str) {
+        println!(
+            "cargo:rerun-if-env-changed={}",
+            EnvVariable::new_link(Some(pkg))
+        );
+        println!("cargo:rerun-if-env-changed={}", EnvVariable::new_link(None));
+
+        let Some(paths) = self.query_path(pkg) else {
+            return;
+        };
+        if self.link_mode(pkg) {
+            return;
+        }
+
+        let target = std::env::var("TARGET")
+            .or_else(|_| std::env::var("HOST"))
+            .unwrap_or_default();
+
+        let rpath_origin = if target.contains("-linux-gnu") || target.contains("-linux-musl") {
+            "$ORIGIN"
+        } else if target.ends_with("-darwin") {
+            "@executable_path"
+        } else {
+            return;
+        };
+
+        let mut lib_dirs: Vec<&std::path::Path> = Vec::new();
+        for path in paths.iter().filter_map(|p| p.parent()) {
+            if path.is_dir() && !lib_dirs.contains(&path) {
+                lib_dirs.push(path);
+            }
+        }
+        for dir in &lib_dirs {
+            let nested = dir
+                .ancestors()
+                .skip(1)
+                .any(|parent| lib_dirs.iter().any(|other| other == &parent));
+            if !nested {
+                println!("cargo:rustc-link-search=native={}", dir.display());
+            }
+        }
+
+        if rpath_origin == "$ORIGIN" {
+            println!(
+                "cargo:rustc-link-arg=-Wl,--disable-new-dtags,-rpath,{rpath_origin}/{runtime_subdir}"
+            );
+        } else {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{rpath_origin}/{runtime_subdir}");
+        }
+    }
+
     fn probe_full(mut self) -> Result<Dependencies, Error> {
         let mut libraries = self.probe_pkg_config()?;
         libraries.override_from_flags(&self.env);
@@ -980,13 +1085,15 @@ impl Config {
             // `Some` only for a dep served by a downloaded binary bundle.
             // TODO: Pass package version here
             let prebuilt_pkg_config_paths = self.query_path(name);
+            let prebuilt = prebuilt_pkg_config_paths.is_some_and(|paths| !paths.is_empty());
 
-            // should the lib be statically linked?
-            let statik = cfg!(feature = "binary")
-                || self
-                    .env
-                    .has_value(&EnvVariable::new_link(Some(name)), "static")
-                || self.env.has_value(&EnvVariable::new_link(None), "static");
+            let statik = self.link_mode(name);
+
+            if let Some(provider) = self.provider(name).filter(|provider| *provider != name) {
+                if !libraries.providers.iter().any(|p| p == provider) {
+                    libraries.providers.push(provider.to_string());
+                }
+            }
 
             let mut library = if self.env.contains(&EnvVariable::new_no_pkg_config(name)) {
                 Library::from_env_variables(name)
@@ -998,7 +1105,7 @@ impl Config {
                     .print_system_libs(false)
                     .cargo_metadata(false)
                     .range_version(metadata::parse_version(version))
-                    .statik(statik);
+                    .statik(statik || prebuilt);
 
                 // Bundles ship pkg-config 0.29.2, whose `--define-prefix` (on by
                 // default on Windows) miscomputes `prefix` for nested layouts
@@ -1036,7 +1143,27 @@ impl Config {
             libraries.add(name, library);
         }
 
+        self.check_link_modes(&libraries)?;
+
         Ok(libraries)
+    }
+
+    fn check_link_modes(&self, libraries: &Dependencies) -> Result<(), Error> {
+        let mut modes = HashMap::new();
+        for (name, lib) in libraries.iter() {
+            let Some(provider) = self.provider(name) else {
+                continue;
+            };
+            if let Some(statik) = modes.insert(provider, lib.statik) {
+                if statik != lib.statik {
+                    return Err(Error::LinkModeMismatch(
+                        provider.to_string(),
+                        name.to_string(),
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 
     fn probe_with_fallback<'a>(

--- a/src/test.rs
+++ b/src/test.rs
@@ -1125,7 +1125,7 @@ fn static_one_lib() {
     .unwrap();
 
     let testdata = libraries.get_by_name("testdata").unwrap();
-    assert!(testdata.statik == cfg!(feature = "binary"));
+    assert!(!testdata.statik);
 
     let testlib = libraries.get_by_name("teststaticlib").unwrap();
     assert!(testlib.statik);

--- a/src/test_binary.rs
+++ b/src/test_binary.rs
@@ -18,7 +18,7 @@ use system_deps_meta::{
     BUILD_MANIFEST, TARGET_DIR,
 };
 
-use crate::{BuildInternalClosureError, Config, EnvVariables, Library};
+use crate::{BuildInternalClosureError, Config, Dependencies, EnvVariables, Library};
 
 #[derive(Debug)]
 struct Test {
@@ -567,6 +567,93 @@ fn probe() -> Result<(), Error> {
     assert!(testlib.statik);
 
     Ok(())
+}
+
+fn provider_paths() -> &'static Paths {
+    static PATHS: OnceLock<Paths> = OnceLock::new();
+    PATHS.get_or_init(|| {
+        let pkgs = vec![Package {
+            name: "test",
+            deps: vec![],
+            config: toml::toml![
+                [package.metadata.system-deps.test]
+                name = "test"
+                url = "$TEST"
+                paths = [ "lib/pkgconfig" ]
+                provides = [ "dep", "wild*" ]
+            ],
+        }];
+        Test::new("link_mode", pkgs)
+            .expect("failed to write test metadata")
+            .paths
+    })
+}
+
+fn config_with(vars: HashMap<&'static str, String>) -> Config {
+    let mut config = Config::new_with_env(EnvVariables::Mock(vars));
+    config.paths = provider_paths();
+    config
+}
+
+#[test]
+fn link_mode() {
+    let paths = provider_paths();
+    assert_eq!(paths.provider("test"), Some("test"));
+    assert_eq!(paths.provider("dep"), Some("test"));
+    assert_eq!(paths.provider("wildcard"), Some("test"));
+    assert_eq!(paths.provider("unrelated"), None);
+
+    let empty = config_with(HashMap::new());
+    assert!(empty.link_mode("test"));
+    assert!(empty.link_mode("dep"));
+    assert!(empty.link_mode("wildcard"));
+    assert!(!empty.link_mode("unrelated"));
+
+    let provided = config_with(HashMap::from([("SYSTEM_DEPS_TEST_LINK", "dynamic".into())]));
+    assert!(!provided.link_mode("test"));
+    assert!(!provided.link_mode("dep"));
+    assert!(!provided.link_mode("wildcard"));
+
+    let provided = config_with(HashMap::from([("SYSTEM_DEPS_TEST_LINK", "static".into())]));
+    assert!(provided.link_mode("dep"));
+    assert!(!provided.link_mode("unrelated"));
+
+    let global = config_with(HashMap::from([("SYSTEM_DEPS_LINK", "static".into())]));
+    assert!(global.link_mode("dep"));
+    assert!(global.link_mode("unrelated"));
+
+    let per_pkg = config_with(HashMap::from([
+        ("SYSTEM_DEPS_TEST_LINK", "dynamic".into()),
+        ("SYSTEM_DEPS_DEP_LINK", "static".into()),
+    ]));
+    assert!(!per_pkg.link_mode("test"));
+    assert!(per_pkg.link_mode("dep"));
+}
+
+#[test]
+fn link_modes_must_match() {
+    let config = config_with(HashMap::new());
+    let lib = |name: &str, statik: bool| {
+        let mut lib = Library::from_env_variables(name);
+        lib.statik = statik;
+        lib
+    };
+
+    let mut libs = Dependencies::default();
+    libs.add("test", lib("test", true));
+    libs.add("dep", lib("dep", true));
+    assert!(config.check_link_modes(&libs).is_ok());
+
+    libs.add("wildcard", lib("wildcard", false));
+    assert!(matches!(
+        config.check_link_modes(&libs),
+        Err(crate::Error::LinkModeMismatch(_, _))
+    ));
+
+    let mut libs = Dependencies::default();
+    libs.add("test", lib("test", true));
+    libs.add("unrelated", lib("unrelated", false));
+    assert!(config.check_link_modes(&libs).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Prebuilt binaries can come with static and shared libraries (gstreamer bundles come with both). The initial support for them forced static linking, but dynamic linking may be beneficial for some applications, especially when dealing with licenses. This is motivated by an experiment to support dynamic linking of gstreamer from the downloaded bundles.

This patch makes it so the `SYSTEM_DEPS_LINK` environment variable works for prebuilt binaries too. In this case, the default remains static to avoid breaking the previous behaviour. It doesn't affect the probing of system-installed libraries at all.

Note that this mode only changes how libraries are linked. Deployment is out of scope, and left entirely to the applications using `system-deps`, meaning they are responsible for placing the libraries in the correct place and setting the relevant paths in the binary. We already provide `Config::query_path`, which gives the path of the extracted bundle so applications can distribute it as they see fit.