### PR TITLE
Wrap `PKG_CONFIG_PATH_FOR_TARGET` if present

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1309,23 +1309,32 @@ impl Library {
         f: impl FnOnce() -> Result<R, pkg_config::Error>,
     ) -> Result<R, pkg_config::Error> {
         // Save current PKG_CONFIG_PATH, so we can restore it
-        let prev = env::var("PKG_CONFIG_PATH").ok();
+        let prev =
+            &["PKG_CONFIG_PATH", "PKG_CONFIG_PATH_FOR_TARGET"].map(|var| (var, env::var_os(var)));
 
-        let prev_paths = prev.iter().flat_map(env::split_paths).collect::<Vec<_>>();
-        let joined_paths = pkg_config_paths.join_paths(prev_paths.as_slice());
+        for (var, value) in prev {
+            let Some(value) = value else {
+                continue;
+            };
+            let paths: Vec<_> = env::split_paths(value).collect();
+            let joined = pkg_config_paths.join_paths(&paths);
 
-        // pkg-config 0.29.2 eats `\` while expanding `${pcfiledir}`, producing
-        // corrupt flags (e.g. `C:Userslibpkgconfig`). Forward slashes work on
-        // Windows and avoid this; there `\` is only ever a path separator.
-        #[cfg(windows)]
-        let joined_paths = OsString::from(joined_paths.to_string_lossy().replace('\\', "/"));
+            // pkg-config 0.29.2 eats `\` while expanding `${pcfiledir}`, producing
+            // corrupt flags (e.g. `C:Userslibpkgconfig`). Forward slashes work on
+            // Windows and avoid this; there `\` is only ever a path separator.
+            #[cfg(windows)]
+            let joined = OsString::from(joined.to_string_lossy().replace('\\', "/"));
 
-        env::set_var("PKG_CONFIG_PATH", joined_paths);
+            env::set_var(var, joined);
+        }
 
         let res = f();
 
-        if let Some(prev) = prev {
-            env::set_var("PKG_CONFIG_PATH", prev);
+        for (var, value) in prev {
+            match value {
+                Some(val) => env::set_var(var, val),
+                None => env::remove_var(var),
+            }
         }
 
         res


### PR DESCRIPTION
When compiling inside of a Nix shell things can get a bit tricky. There is a [`_FOR_TARGET` suffix](https://github.com/NixOS/nixpkgs/blob/86436ff541dd2c50dc0c5323044f98acaf456e2f/pkgs/build-support/setup-hooks/role.bash#L17) that can get applied to env variables, making them take precedence. This happens because `pkg-config` is [wrapped](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/build-support/pkg-config-wrapper/default.nix) to inject the correct store paths of all build inputs.

This affects us. At the moment, if we build a rust crate that uses binaries, they won't get added to the search path, since they would be in `PKG_CONFIG_PATH`, and Nix would look in `PKG_CONFIG_PATH_FOR_TARGET`. One might think about unsetting this one then, but that would break system library dependencies added to the shell (i.e. openssl, gl, etc...).

So, this patch adds support for wrapping multiple `PKG_CONFIG_PATH` variables. For now, if there is a `_FOR_TARGET` option, it will also temporarily prefix it with the binary path.

Also fixes an oversight, it didn't remove the variable if `prev` was `None`.